### PR TITLE
Add missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='cirqqulacs',
-    version='0.0.3',
-    author='QunaSys',
-    author_email='qulacs@qunasys.com',
-    url='http://www.qulacs.org',
-    description='Fast quantum circuit simulator Qulacs as backend for Cirq',
-    long_description='',
-    license='MIT',
-    packages=find_packages(exclude=['tests']),
+    name="cirqqulacs",
+    version="0.0.3",
+    author="QunaSys",
+    author_email="qulacs@qunasys.com",
+    url="http://www.qulacs.org",
+    description="Fast quantum circuit simulator Qulacs as backend for Cirq",
+    long_description="",
+    license="MIT",
+    install_requires=["cirq", "qulacs"],
+    packages=find_packages(exclude=["tests"]),
 )


### PR DESCRIPTION
This pull request adds `qulacs` and `cirq` to `install_required` in setup.py.